### PR TITLE
Correção de loop infinito no plugin do TinyMCE ao usar setContent

### DIFF
--- a/packages/canary-client/public/tinymce/plugins/mergetags/index.js
+++ b/packages/canary-client/public/tinymce/plugins/mergetags/index.js
@@ -1,19 +1,26 @@
 (function () {
     tinymce.PluginManager.add("mergetags", function (editor, url) {
         const tags = editor.getParam("mergetags_list", []);
+        let isSettingContent = false;
 
         // Converter `{{variavel}}` para <span class="mergetags">
         editor.on("SetContent", function (e) {
+            if (isSettingContent) return; // Se já estiver definindo conteúdo, saia
+            isSettingContent = true; // Marque que estamos definindo conteúdo
+
             const parser = new DOMParser();
             const doc = parser.parseFromString(e.content || editor.getContent({ format: "html" }), "text/html");
+
             // Manipula apenas quando o conteúdo é inserido de maneira clean, sem as tags de estilização
-            // e direto pelo metódo editor.setContent()
+            // e direto pelo método editor.setContent()
             // Usar o e.set evita manipular o conteúdo quando outro plugin usar o insertContent
             if (e.set && doc.querySelectorAll("span.mergetags").length === 0) {
                 let content = editor.getContent({ format: "html" });
-                content = content.replace(/\{\{\s*(.*?)\s*\}\}/g, '<span class="mergetags" contenteditable="false"><span class="mergetags-affix">{{</span>$1<span class="mergetags-affix">}}</span></span>')
+                content = content.replace(/\{\{\s*(.*?)\s*\}\}/g, '<span class="mergetags" contenteditable="false"><span class="mergetags-affix">{{</span>$1<span class="mergetags-affix">}}</span></span>');
                 editor.setContent(content);
             }
+
+            isSettingContent = false; // Marque que terminamos de definir conteúdo
         });
 
         // Antes de salvar, remover os <span> e deixar só {{ variavel }}


### PR DESCRIPTION
## Contexto
Ao implementar o método SetContent para manipulação do conteúdo do editor apresentava um erro no carregamento, gerando um loop infinito que impedia a edição do texto HTML

## Analisando o problema
O problema com o loop infinito ao usar o método setContent no TinyMCE ocorre porque o evento SetContent é disparado novamente toda vez que você chama editor.setContent, criando um ciclo infinito. Isso acontece porque o evento SetContent é acionado tanto quando o conteúdo é definido programaticamente, quanto quando o usuário insere conteúdo manualmente.

## O que foi feito
- [ ] Adicionei uma flag (isSettingContent) para evitar recursão infinita no evento SetContent.
- [ ] A flag garante que editor.setContent não seja chamado repetidamente dentro do mesmo evento.