### PR TITLE
Adjusted mergetags style

### DIFF
--- a/packages/canary-client/public/tinymce/plugins/mergetags/index.js
+++ b/packages/canary-client/public/tinymce/plugins/mergetags/index.js
@@ -95,14 +95,21 @@
         });
 
         const insertTag = (editor, value) => {
-            editor.insertContent(`<span class="mergetags"><span class="mergetags-affix">{{</span>${value}<span class="mergetags-affix">}}</span></span>`);
+            editor.insertContent(
+              `<span class="mergetags" data-variable="${value}" contenteditable="false">
+                <span class="mergetags-affix">{{</span>
+                <span class="mergetags-value" contenteditable="true">${value}</span>
+                <span class="mergetags-affix">}}</span>
+              </span>`
+            );
+            // Posiciona o cursor após a variável
             editor.selection.collapse(false);
-        }
+          };
 
         return {
             getMetadata: function () {
                 return {
-                    name: "Váriaveis"
+                    name: "Váriaveis"   
                 };
             }
         };

--- a/packages/canary-client/public/tinymce/plugins/mergetags/index.js
+++ b/packages/canary-client/public/tinymce/plugins/mergetags/index.js
@@ -95,7 +95,7 @@
         });
 
         const insertTag = (editor, value) => {
-            editor.insertContent(`<span class="mergetags" contenteditable="false"><span class="mergetags-affix">{{</span>${value}<span class="mergetags-affix">}}</span></span>`);
+            editor.insertContent(`<span class="mergetags"><span class="mergetags-affix">{{</span>${value}<span class="mergetags-affix">}}</span></span>`);
             editor.selection.collapse(false);
         }
 

--- a/packages/canary-client/public/tinymce/plugins/mergetags/index.js
+++ b/packages/canary-client/public/tinymce/plugins/mergetags/index.js
@@ -109,7 +109,7 @@
         return {
             getMetadata: function () {
                 return {
-                    name: "Váriaveis"   
+                    name: "Váriaveis"
                 };
             }
         };

--- a/packages/canary-client/src/scenes/WidgetActions/Settings/HTMLField/index.tsx
+++ b/packages/canary-client/src/scenes/WidgetActions/Settings/HTMLField/index.tsx
@@ -91,18 +91,7 @@ const tinyInitSettings = {
   images_upload_handler: S3UploadHandler,
   skin: false,  // Necessário para evitar erro de skin ao usar localmente
   contextmenu: "social link image",
-  content_style: `
-  body { font-family: 'Source Sans Pro', 'Proxima Nova', sans-serif; }
-  span.mergetags {
-      background-color: #f0f0f0;
-      padding: 0 2px;
-      border-radius: 3px;
-      border: 1px dashed #ccc;
-  }
-  span.mergetags-affix {
-      color: #666;
-  }
-`,
+  content_style: "body { font-family: 'Source Sans Pro', 'Proxima Nova', sans-serif; }",
   content_css: [
     "https://fonts.googleapis.com/css?family=Abel|Anton|Archivo+Narrow:400,400i,700,700i|Arvo:400,400i,700,700i|Asap:400,400i,700,700i|Baloo+Bhai|Bitter:400,400i,700|Bree+Serif|Cabin:400,400i,700,700i|Catamaran:400,700|Crimson+Text:400,400i,700,700i|Cuprum:400,400i,700,700i|David+Libre:400,700|Dosis:400,700|Droid+Sans:400,700|Exo+2:400,400i,700,700i|Exo:400,400i,700,700i|Fira+Sans:400,400i,700,700i|Fjalla+One|Francois+One|Gidugu|Hind:400,700|Inconsolata:400,700|Indie+Flower|Josefin+Sans:400,400i,700,700i|Karla:400,400i,700,700i|Lalezar|Lato:400,400i,700,700i|Libre+Baskerville:400,400i,700|Lobster|Lora:400,400i,700,700i|Merriweather+Sans:400,400i,700,700i|Montserrat:400,700|Muli:400,400i|Noto+Serif:400,400i,700,700i|Nunito:400,700|Open+Sans+Condensed:300,300i,700|Open+Sans:400,400i,700,700i|Oswald:400,700|Oxygen:400,700|PT+Sans:400,400i,700,700i|PT+Serif:400,400i,700,700i|Pacifico|Playfair+Display:400,400i,700,700i|Poiret+One|Poppins:400,700|Quicksand:400,700|Raleway:400,400i,700,700i|Roboto+Condensed:400,400i,700,700i|Roboto+Mono:400,400i,700,700i|Roboto+Slab:400,700|Roboto:400,400i,700,700i|Ruslan+Display|Signika:400,700|Slabo+27px|Titillium+Web:400,400i,700,700i|Ubuntu+Condensed|Ubuntu:400,400i,700,700i|Varela+Round|Yanone+Kaffeesatz:400,700",
     "/styles/plugins/social.css",

--- a/packages/canary-client/src/scenes/WidgetActions/Settings/HTMLField/index.tsx
+++ b/packages/canary-client/src/scenes/WidgetActions/Settings/HTMLField/index.tsx
@@ -91,7 +91,18 @@ const tinyInitSettings = {
   images_upload_handler: S3UploadHandler,
   skin: false,  // Necessário para evitar erro de skin ao usar localmente
   contextmenu: "social link image",
-  content_style: "body { font-family: 'Source Sans Pro', 'Proxima Nova', sans-serif; }",
+  content_style: `
+  body { font-family: 'Source Sans Pro', 'Proxima Nova', sans-serif; }
+  span.mergetags {
+      background-color: #f0f0f0;
+      padding: 0 2px;
+      border-radius: 3px;
+      border: 1px dashed #ccc;
+  }
+  span.mergetags-affix {
+      color: #666;
+  }
+`,
   content_css: [
     "https://fonts.googleapis.com/css?family=Abel|Anton|Archivo+Narrow:400,400i,700,700i|Arvo:400,400i,700,700i|Asap:400,400i,700,700i|Baloo+Bhai|Bitter:400,400i,700|Bree+Serif|Cabin:400,400i,700,700i|Catamaran:400,700|Crimson+Text:400,400i,700,700i|Cuprum:400,400i,700,700i|David+Libre:400,700|Dosis:400,700|Droid+Sans:400,700|Exo+2:400,400i,700,700i|Exo:400,400i,700,700i|Fira+Sans:400,400i,700,700i|Fjalla+One|Francois+One|Gidugu|Hind:400,700|Inconsolata:400,700|Indie+Flower|Josefin+Sans:400,400i,700,700i|Karla:400,400i,700,700i|Lalezar|Lato:400,400i,700,700i|Libre+Baskerville:400,400i,700|Lobster|Lora:400,400i,700,700i|Merriweather+Sans:400,400i,700,700i|Montserrat:400,700|Muli:400,400i|Noto+Serif:400,400i,700,700i|Nunito:400,700|Open+Sans+Condensed:300,300i,700|Open+Sans:400,400i,700,700i|Oswald:400,700|Oxygen:400,700|PT+Sans:400,400i,700,700i|PT+Serif:400,400i,700,700i|Pacifico|Playfair+Display:400,400i,700,700i|Poiret+One|Poppins:400,700|Quicksand:400,700|Raleway:400,400i,700,700i|Roboto+Condensed:400,400i,700,700i|Roboto+Mono:400,400i,700,700i|Roboto+Slab:400,700|Roboto:400,400i,700,700i|Ruslan+Display|Signika:400,700|Slabo+27px|Titillium+Web:400,400i,700,700i|Ubuntu+Condensed|Ubuntu:400,400i,700,700i|Varela+Round|Yanone+Kaffeesatz:400,700",
     "/styles/plugins/social.css",


### PR DESCRIPTION
## Contexto
O problema ocorre porque seu plugin _mergetags_ está definindo as variáveis como `contenteditable="false"`, o que impede que elas sejam formatadas junto com o texto ao redor. Isso é intencional para proteger a estrutura das variáveis, mas tem o efeito colateral de impedir a formatação visual.

## Solução
A ideia é de modificar a abordagem para permitir que a formatação seja aplicada às variáveis enquanto ainda mantém sua estrutura protegida. Foi modificado o plugin para não usar `contenteditable="false"` e em vez disso usar CSS para proteger visualmente as variáveis.

## Checklist
- [x] Toda formatação de estilo como negrito, itálico ou cores de fontes devem ser aplicadas às variáveis durante a edição no TinyMCE.

## Issues linkadas
- [x] [Aplicar estilos nas variáveis (Não está funcionando no editor uma váriavel com itálico por exemplo ou cor diferente)](https://app.asana.com/0/1161468210277385/1209857981406589/f)

## Preview:
<img width="985" alt="Captura de Tela 2025-04-02 às 16 48 00" src="https://github.com/user-attachments/assets/da33d528-79de-47d2-b4f6-387eb033deb1" />