### PR TITLE
feat: added team field when reading qr code

### DIFF
--- a/packages/canary-client/src/scenes/WidgetActions/Settings/Plips/QRForm.tsx
+++ b/packages/canary-client/src/scenes/WidgetActions/Settings/Plips/QRForm.tsx
@@ -16,6 +16,7 @@ const GET_PLIP_SIGNATURES = gql`
       expected_signatures
       state: form_data(path: "state")
       name: form_data(path: "name")
+      team: form_data(path: "team")
       created_at
     }
 
@@ -141,6 +142,7 @@ export const QRForm: React.FC<Properties> = ({ widget }) => {
           />
           <Text>
             Ficha de <strong>{plipForm?.state}</strong> gerada por <strong>{plipForm?.name}</strong>
+            {plipForm?.team ? `, da equipe ${plipForm.team}` : ''}
             {plipSignaturesAgg.aggregate.count > 0
               ? `, que já enviou ${plipSignaturesAgg.aggregate.sum.confirmed_signatures} assinaturas anteriormente.`
               : `.`


### PR DESCRIPTION

## Contexto
Adiciona a informação a qual equipe a ficha emitida pertence quando há a chave `team` em plips.form_data.

## Checklist
- [X] Exibe o nome da equipe ao ler qr code (apenas quando há equipe)

## Screenshots
<img width="828" height="618" alt="image" src="https://github.com/user-attachments/assets/706c09c3-6d97-46b5-9145-adf752caa9f2" />