### PR TITLE
fix(autofire): adjust formatting and create a test submission button

### DIFF
--- a/packages/canary-client/src/scenes/WidgetActions/Settings/Autofire/index.tsx
+++ b/packages/canary-client/src/scenes/WidgetActions/Settings/Autofire/index.tsx
@@ -1,6 +1,7 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import styled from 'styled-components';
+import { useMutation, gql } from 'bonde-core-tools';
 
 import { InputField, Validators } from 'bonde-components';
 import {
@@ -9,16 +10,26 @@ import {
   Flex,
   Grid,
   GridItem,
-  Heading
+  Heading,
+  FormControl,
+  FormLabel,
+  Input,
+  Text
 } from "bonde-components/chakra";
-
-
 
 import { noSpecialCharacters } from "../../../../services/utils";
 import { Widget } from "../../FetchWidgets";
 import SettingsForm from '../SettingsForm';
 import EmailMetrics from './EmailMetrics';
 import HTMLField from "../HTMLField";
+
+const SendEmailMutation = gql`
+  mutation Notify($input: [NotifyInput!]!) {
+    notify(input: $input) {
+      status
+    }
+  }
+`;
 
 const Styles = styled.div`
   .emailBody {
@@ -28,8 +39,7 @@ const Styles = styled.div`
   .emailBody--label {
     padding-bottom: 4px;
   }
-`
-
+`;
 
 type Props = {
   widget: Widget;
@@ -40,15 +50,82 @@ const { required, composeValidators, isEmail } = Validators;
 
 const AutofireForm = ({ widget, updateCache }: Props): React.ReactElement => {
   const { t } = useTranslation("widgetActions");
+  const [sendEmail] = useMutation(SendEmailMutation);
+  const [testEmail, setTestEmail] = useState("");
+  const [isSending, setIsSending] = useState(false);
+  const [emailSent, setEmailSent] = useState(false);
+  const [lastSentConfig, setLastSentConfig] = useState<any>(null);
 
-  console.log("settings", { settings: widget.settings });
+  // Verifica se algum campo foi alterado após o envio
+  useEffect(() => {
+    if (emailSent && lastSentConfig) {
+      const configChanged = 
+        lastSentConfig.sender_name !== widget.settings.sender_name ||
+        lastSentConfig.sender_email !== widget.settings.sender_email ||
+        lastSentConfig.email_subject !== widget.settings.email_subject ||
+        lastSentConfig.email_text !== widget.settings.email_text;
+      
+      if (configChanged) {
+        setEmailSent(false);
+        setLastSentConfig(null);
+      }
+    }
+  }, [widget.settings, emailSent, lastSentConfig]);
+
+  const sendEmailTest = async () => {
+    console.log("Iniciando envio de email de teste...");
+    
+    if (!testEmail) {
+      return;
+    }
+
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(testEmail)) {
+      return;
+    }
+
+    // Verifica se os campos estão preenchidos
+    if (!widget.settings.sender_name || !widget.settings.sender_email || 
+        !widget.settings.email_subject || !widget.settings.email_text) {
+      return;
+    }
+
+    setIsSending(true);
+    
+    try {
+      const emailOpts: any = {
+        email_to: testEmail,
+        subject: `[TESTE] ${widget.settings.email_subject}`,
+        body: widget.settings.email_text,
+        email_from: `${widget.settings.sender_name} <${widget.settings.sender_email}>`,
+        context: {}
+      };
+      
+      console.log("Enviando email com as opções:", emailOpts);
+      const result = await sendEmail({ variables: { input: emailOpts } });
+      console.log("Resultado do envio:", result);
+      
+      setLastSentConfig({
+        sender_name: widget.settings.sender_name,
+        sender_email: widget.settings.sender_email,
+        email_subject: widget.settings.email_subject,
+        email_text: widget.settings.email_text
+      });
+      setEmailSent(true);
+      
+    } catch (error) {
+      console.error("Erro ao enviar email de teste:", error);
+    } finally {
+      setIsSending(false);
+    }
+  };
 
   return (
     <Styles>
       <SettingsForm
         widget={widget}
-        afterSubmit={async (values:any, result:any) => {
-          updateCache(result.data.update_widgets.returning[0])
+        afterSubmit={async (values: any, result: any) => {
+          updateCache(result.data.update_widgets.returning[0]);
         }}
         initialValues={{
           settings: widget.settings
@@ -58,7 +135,9 @@ const AutofireForm = ({ widget, updateCache }: Props): React.ReactElement => {
           <Grid templateColumns="repeat(12, 1fr)" gap={16}>
             <GridItem colSpan={[12, 12, 6]}>
               <Box bg="white" p={6} boxShadow="sm">
-                <Heading as="h3" size="xl" mb={4}>{t("settings.autofire.title")}</Heading>
+                <Heading as="h3" size="xl" mb={4}>
+                  {t("settings.autofire.title")}
+                </Heading>
                 <InputField
                   label={t("settings.autofire.label.sendersName")}
                   name="settings.sender_name"
@@ -96,13 +175,45 @@ const AutofireForm = ({ widget, updateCache }: Props): React.ReactElement => {
                   )}
                   mode="email"
                 />
-                <Flex justify='end'>
-                  <Button disabled={submitting || !dirty} type='submit'>{t('settings.defaultForm.submit')}</Button>
+                <Flex justify="end">
+                  <Button disabled={submitting || !dirty} type="submit">
+                    {t('settings.defaultForm.submit')}
+                  </Button>
                 </Flex>
               </Box>
             </GridItem>
             <GridItem colSpan={[12, 12, 6]}>
-              <EmailMetrics widgetId={widget.id} />
+              <Box bg="white" p={6} boxShadow="sm">
+                <Heading as="h3" size="lg" mb={4}>
+                  Enviar Email de Teste
+                </Heading>
+                <Text mb={4} color="gray.600">
+                  Envie um email de teste para verificar como ele ficará antes de ativar o autofire.
+                </Text>
+                <FormControl mb={4}>
+                  <FormLabel>Email para teste</FormLabel>
+                  <Input
+                    type="email"
+                    placeholder="seu-email@exemplo.com"
+                    value={testEmail}
+                    onChange={(e) => setTestEmail(e.target.value)}
+                  />
+                </FormControl>
+                <Button 
+                  colorScheme="blue" 
+                  onClick={sendEmailTest}
+                  isLoading={isSending}
+                  loadingText="Enviando..."
+                  width="full"
+                >
+                  Enviar Email de Teste
+                </Button>
+                {emailSent && (
+                  <Text mt={2} fontSize="sm" color="green.600" textAlign="center">
+                    ✓ Email de teste enviado com sucesso para {testEmail}
+                  </Text>
+                )}
+              </Box>
             </GridItem>
           </Grid>
         )}

--- a/packages/canary-client/src/scenes/WidgetActions/Settings/Autofire/index.tsx
+++ b/packages/canary-client/src/scenes/WidgetActions/Settings/Autofire/index.tsx
@@ -188,7 +188,7 @@ const AutofireForm = ({ widget, updateCache }: Props): React.ReactElement => {
                   Enviar Email de Teste
                 </Heading>
                 <Text mb={4} color="gray.600">
-                  Envie um email de teste para verificar como ele ficará antes de ativar o autofire.
+                  Envie um email de teste para verificar como ele ficará antes do lançamento oficial da campanha.
                 </Text>
                 <FormControl mb={4}>
                   <FormLabel>Email para teste</FormLabel>

--- a/packages/canary-client/src/scenes/WidgetActions/Settings/HTMLField/index.tsx
+++ b/packages/canary-client/src/scenes/WidgetActions/Settings/HTMLField/index.tsx
@@ -133,13 +133,23 @@ const HTMLField = ({
     tinyInitSettings.contextmenu = "social " + tinyInitSettings.contextmenu
     tinyInitSettings.toolbar = "templates social mergetags conditional | " + tinyInitSettings.toolbar
   } else if (mode === "email") {
-    // Configs para e-mail
-    tinyInitSettings.forced_root_block = false;
-    tinyInitSettings.force_br_newlines = true;
-    tinyInitSettings.force_p_newlines = false;
-    tinyInitSettings.convert_newlines_to_brs = true;
-    tinyInitSettings.remove_trailing_brs = true;
-    tinyInitSettings.newline_behavior = true;
+    tinyInitSettings.forced_root_block = '';  // Remove wrapper de parágrafo
+    tinyInitSettings.force_br_newlines = true;  // Força uso de <br>
+    tinyInitSettings.force_p_newlines = false;  // Não usa <p>
+    tinyInitSettings.convert_newlines_to_brs = true;  // Converte \n em <br>
+    
+    tinyInitSettings.setup = (editor: any) => {
+      editor.on('keydown', (e: KeyboardEvent) => {
+        if (e.key === 'Enter' && !e.shiftKey) {
+          e.preventDefault();
+          editor.execCommand('mceInsertContent', false, '<br><br>');
+        }
+        else if (e.key === 'Enter' && e.shiftKey) {
+          e.preventDefault();
+          editor.execCommand('mceInsertContent', false, '<br>');
+        }
+      });
+    };
   }
 
 
@@ -164,7 +174,7 @@ const HTMLField = ({
       <Editor
         tinymceScriptSrc="/tinymce/tinymce.min.js"
         onInit={(_evt, editor) => editorRef.current = editor}
-        onChange={(_evt) => input.onChange(editorRef.current.getContent({ format: "clean" }))}
+        onChange={(_evt) => input.onChange(editorRef.current.getContent({ format: "html" }))}
         initialValue={initialValue}
         init={{ ...tinyInitSettings, ...init }}
       />


### PR DESCRIPTION
## Contexto
<!-- Qual problema está tentando resolver? -->
Fazemos disparo de e-mails e armazenamos o HTML das mensagens em JSON na widget. Atualmente existe um problema entre criar um HTML para e-mail e enviá-lo. Muitas das vezes os elementos HTML possuem alguma formatação pre-definida no navegador ou no aplicativo de e-mail utilizado gerando visualizações nada agradáveis. O objetivo é definir um padrão que possa ser replicado para qualquer renderização (Gmail, Mailhog, Hotmail) e auxiliar os usuários no processo de envio de email.

## Checklist
- [x] Ajustar formatação do auto fire
- [x] Implementar funcionalidade para teste de email
- [ ] Realizar testes com mensagem de agradecimento na comunidade Tarifa Zero no ENEM (Meu Rio)
<!-- Descreva as principais alterações que este PR faz. -->

## Issues linkadas
- [[Jardinagem] E-mail de autofire](https://app.asana.com/1/1105567501435500/project/1161468210277385/task/1211861759978203?focus=true) 
<!-- Adicione as respectivas issues linkadas a este PR. -->

## Screenshots
<!-- Adicione algumas imagens para haver um preview da sua tarefa, para ajudar desenvolvedores e designers a entender facilmente no que você está trabalhando. -->

### Preview:
<img width="1307" height="489" alt="testeautofire" src="https://github.com/user-attachments/assets/92778529-52a1-4d9c-87a9-68ebf4140c57" />
