### PR TITLE
Migrate form widget to admin canary

### DIFF
--- a/packages/admin-client/src/mobrender/components/widget.js
+++ b/packages/admin-client/src/mobrender/components/widget.js
@@ -62,7 +62,11 @@ const Widget = ({
               );
               window.open(url, '_self');
             } else {
-              history.push(redirect);
+              const url = urljoin(
+                process.env.REACT_APP_DOMAIN_ADMIN_CANARY,
+                `/widgets/${widget.id}/settings/fields`
+              );
+              window.open(url, '_self');
             }
           }}
           onDelete={() => {

--- a/packages/canary-client/public/locales/en/widgetActions.json
+++ b/packages/canary-client/public/locales/en/widgetActions.json
@@ -37,7 +37,8 @@
       "adjusts": "Ajustes",
       "autofire": "Mensagem de Agradecimento",
       "finish": "Pós-Ação",
-      "integrations": "Integrações"
+      "integrations": "Integrações",
+      "fields": "Campos"
     },
     "defaultForm": {
       "error": "Houve um erro ao salvar o formulário",
@@ -172,6 +173,10 @@
         "radioYes": "Habilitar",
         "radioNo": "Desabilitar"
       }
+    },
+    "fields": {
+      "title": "Campos",
+      "description": "Aqui você pode criar os campos do seu formulário"
     }
   }
 }

--- a/packages/canary-client/public/locales/es/widgetActions.json
+++ b/packages/canary-client/public/locales/es/widgetActions.json
@@ -37,7 +37,8 @@
       "adjusts": "Ajustes",
       "autofire": "Mensagem de Agradecimento",
       "finish": "Pós-Ação",
-      "integrations": "Integrações"
+      "integrations": "Integrações",
+      "fields": "Campos"
     },
     "defaultForm": {
       "error": "Houve um erro ao salvar o formulário",
@@ -172,6 +173,10 @@
         "radioYes": "Habilitar",
         "radioNo": "Desabilitar"
       }
+    },
+    "fields": {
+      "title": "Campos",
+      "description": "Aqui você pode criar os campos do seu formulário"
     }
   }
 }

--- a/packages/canary-client/public/locales/pt-BR/widgetActions.json
+++ b/packages/canary-client/public/locales/pt-BR/widgetActions.json
@@ -31,7 +31,8 @@
       "adjusts": "Ajustes",
       "autofire": "Mensagem de Agradecimento",
       "finish": "Pós-Ação",
-      "integrations": "Integrações"
+      "integrations": "Integrações",
+      "fields": "Campos"
     },
     "defaultForm": {
       "error": "Houve um erro ao salvar o formulário",
@@ -196,6 +197,10 @@
         "radioYes": "Habilitar",
         "radioNo": "Desabilitar"
       }
+    },
+    "fields": {
+      "title": "Campos",
+      "description": "Aqui você pode criar os campos do seu formulário"
     }
   }
 }

--- a/packages/canary-client/src/scenes/WidgetActions/Settings/Fields/index.tsx
+++ b/packages/canary-client/src/scenes/WidgetActions/Settings/Fields/index.tsx
@@ -1,0 +1,214 @@
+import React, { useState, useEffect } from 'react';
+import {
+  Button,
+  Box,
+  Flex,
+  Heading,
+  Grid,
+  GridItem,
+  Text,
+  Select,
+  Input,
+  FormControl,
+  FormLabel,
+  Switch,
+  IconButton,
+  VStack,
+  HStack,
+  Divider
+} from 'bonde-components/chakra';
+import { useTranslation } from 'react-i18next';
+import SettingsForm from '../SettingsForm';
+
+// Componente interno que gerencia os campos
+const FieldsFormContent = ({ fields, setFields, hasChanges, submitting, form, initialFields }: any) => {
+  const { t } = useTranslation('widgetActions');
+
+  const fieldTypes = [
+    { value: 'text', label: 'Texto' },
+    { value: 'email', label: 'E-mail' },
+    { value: 'number', label: 'Telefone' },
+    { value: 'dropdown', label: 'Lista Suspensa' },
+    { value: 'textarea', label: 'Texto Longo' }
+  ];
+
+  const addField = () => {
+    const newField = {
+      uid: `field-${Date.now()}-${Math.floor(Math.random() * 100)}`,
+      kind: 'text',
+      label: '',
+      placeholder: '',
+      required: 'true'
+    };
+    setFields([...fields, newField]);
+  };
+
+  const removeField = (index: number) => {
+    const newFields = fields.filter((_: any, i: number) => i !== index);
+    setFields(newFields);
+  };
+
+  const updateField = (index: number, field: string, value: any) => {
+    const newFields = fields.map((f: any, i: number) => 
+      i === index ? { ...f, [field]: value } : f
+    );
+    setFields(newFields);
+  };
+
+  // Atualiza o campo do formulário sempre que fields mudar
+  useEffect(() => {
+    if (form && form.change) {
+      form.change('settings.fields', JSON.stringify(fields));
+    }
+  }, [fields, form]);
+
+  return (
+    <Grid templateColumns="repeat(12, 1fr)" gap={16}>
+      <GridItem colSpan={[12, 12, 8]}>
+        <Box bg="white" p={6} boxShadow="sm">
+          <Heading as="h3" size="xl" mb={4}>
+            {t("settings.fields.title")}
+          </Heading>
+          
+          <Text mb={6} color="gray.600">
+            {t('settings.fields.description')}
+          </Text>
+
+          {/* Campos do formulário */}
+          <VStack spacing={6} align="stretch" mb={6}>
+            {fields.map((field: any, index: number) => (
+              <Box key={field.uid} p={4} border="1px" borderColor="gray.200" borderRadius="md">
+                <HStack justify="space-between" mb={4}>
+                  <Heading as="h4" size="md">
+                    Campo {index + 1}
+                  </Heading>
+                  <IconButton
+                    aria-label="Remover campo"
+                    size="sm"
+                    colorScheme="red"
+                    variant="ghost"
+                    onClick={() => removeField(index)}
+                  />
+                </HStack>
+
+                <Grid templateColumns="repeat(2, 1fr)" gap={4} mb={4}>
+                  <FormControl>
+                    <FormLabel>Tipo do Campo</FormLabel>
+                    <Select
+                      value={field.kind}
+                      onChange={(e) => updateField(index, 'kind', e.target.value)}
+                    >
+                      {fieldTypes.map(type => (
+                        <option key={type.value} value={type.value}>
+                          {type.label}
+                        </option>
+                      ))}
+                    </Select>
+                  </FormControl>
+
+                  <FormControl>
+                    <FormLabel>Label</FormLabel>
+                    <Input
+                      value={field.label}
+                      onChange={(e) => updateField(index, 'label', e.target.value)}
+                      placeholder="Ex: Nome completo"
+                    />
+                  </FormControl>
+                </Grid>
+
+                <FormControl mb={4}>
+                  <FormLabel>Placeholder</FormLabel>
+                  <Input
+                    value={field.placeholder}
+                    onChange={(e) => updateField(index, 'placeholder', e.target.value)}
+                    placeholder="Ex: Digite seu nome"
+                  />
+                </FormControl>
+
+                <FormControl display="flex" alignItems="center">
+                  <FormLabel mb={0}>
+                    Campo obrigatório?
+                  </FormLabel>
+                  <Switch
+                    isChecked={field.required === 'true'}
+                    onChange={(e) => updateField(index, 'required', e.target.checked ? 'true' : 'false')}
+                    colorScheme="green"
+                  />
+                </FormControl>
+              </Box>
+            ))}
+          </VStack>
+
+          {/* Botão para adicionar campo */}
+          <Button
+            onClick={addField}
+            variant="outline"
+            mb={6}
+            width="100%"
+          >
+            Adicionar Campo
+          </Button>
+
+          <Divider mb={6} />
+
+          {/* Campo hidden para o formulário */}
+          <input
+            type="hidden"
+            name="settings.fields"
+            value={JSON.stringify(fields)}
+          />
+
+          <Flex justify='end' mt={6}>
+            <Button 
+              disabled={submitting || !hasChanges} 
+              type='submit'
+              colorScheme={hasChanges ? 'green' : 'gray'}
+            >
+              {hasChanges ? 'Salvar Alterações' : t('settings.defaultForm.submit')}
+            </Button>
+          </Flex>
+        </Box>
+      </GridItem>
+    </Grid>
+  );
+};
+
+// Componente principal
+const FieldsSettings = ({ widget, updateCache }: any) => {
+  // Parse dos campos existentes ou array vazio
+  const initialFields = widget.settings.fields 
+    ? JSON.parse(widget.settings.fields)
+    : [];
+
+  const [fields, setFields] = useState(initialFields);
+
+  // Verifica se há mudanças
+  const hasChanges = JSON.stringify(fields) !== JSON.stringify(initialFields);
+
+  return (
+    <SettingsForm
+      widget={widget}
+      afterSubmit={async (values: any, result: any) => {
+        updateCache(result.data.update_widgets.returning[0]);
+      }}
+      initialValues={{
+        settings: {
+          fields: JSON.stringify(fields),
+        }
+      }}
+    >
+      {({ submitting, form }: any) => (
+        <FieldsFormContent 
+          fields={fields}
+          setFields={setFields}
+          hasChanges={hasChanges}
+          submitting={submitting}
+          form={form}
+          initialFields={initialFields}
+        />
+      )}
+    </SettingsForm>
+  );
+};
+
+export default FieldsSettings;

--- a/packages/canary-client/src/scenes/WidgetActions/Settings/Fields/index.tsx
+++ b/packages/canary-client/src/scenes/WidgetActions/Settings/Fields/index.tsx
@@ -117,7 +117,7 @@ const FieldsFormContent = ({ fields, setFields, hasChanges, submitting, form, in
                 </Grid>
 
                 <FormControl mb={4}>
-                  <FormLabel>Placeholder</FormLabel>
+                  <FormLabel>Texto de ajuda</FormLabel>
                   <Input
                     value={field.placeholder}
                     onChange={(e) => updateField(index, 'placeholder', e.target.value)}
@@ -126,7 +126,7 @@ const FieldsFormContent = ({ fields, setFields, hasChanges, submitting, form, in
                 </FormControl>
 
                 <FormControl display="flex" alignItems="center">
-                  <FormLabel mb={0}>
+                  <FormLabel mb={0} mr={2}>
                     Campo obrigatório?
                   </FormLabel>
                   <Switch

--- a/packages/canary-client/src/scenes/WidgetActions/Settings/Navigation.tsx
+++ b/packages/canary-client/src/scenes/WidgetActions/Settings/Navigation.tsx
@@ -63,6 +63,16 @@ const Navigation: React.FC<NavigationProps> = ({ widget }) => {
         <Flex direction="row" mb={3}>
           {tabs && tabs({ push, is })}
 
+          {/* Aba Fields apenas para widgets do tipo form */}
+          {widget.kind === "form" && (
+            <Tab
+              active={is(/\/widgets\/\d+\/settings\/fields\/*$/)}
+              onClick={() => push(`/fields`)}
+            >
+              {t("settings.navigation.fields")}
+            </Tab>
+          )}
+
           <Tab
             active={is(/\/widgets\/\d+\/settings\/adjusts\/*$/)}
             onClick={() => push(`/adjusts`)}

--- a/packages/canary-client/src/scenes/WidgetActions/Settings/index.tsx
+++ b/packages/canary-client/src/scenes/WidgetActions/Settings/index.tsx
@@ -12,6 +12,7 @@ import Labels from "../Labels";
 import Navigation from './Navigation';
 import Adjusts from './Adjusts';
 import Autofire from "./Autofire";
+import Fields from "./Fields";
 
 import ConfigurePostAction from "./ConfigurePostAction";
 import Performance from "./Pressure";
@@ -50,7 +51,6 @@ const RoutesByKind: React.FC<RoutesByKindProps> = ({ widget, updateCache }) => {
       </Route>
     )
   } else {
-    console.log("asdadasdasdasd");
     return (
       <Redirect
         from={`${match.path}`}
@@ -138,6 +138,11 @@ const Settings: React.FC<Props> = ({ widgets }) => {
         <Route exact path={`${match.path}/integrations`}>
           <IntegrationsFields widget={widget} updateCache={updateCache} />
         </Route>
+        {widget.kind === "form" && (
+          <Route exact path={`${match.path}/fields`}>
+            <Fields widget={widget} updateCache={updateCache} />
+          </Route>
+        )}
         {/* Render scenes to settings widget by kind */}
         <RoutesByKind widget={widget} updateCache={updateCache} />
       </Switch>


### PR DESCRIPTION
# Contexto
Criamos uma [frente de trabalho para migrar a widget de formulário do Bonde para o Admin-Canary](https://app.asana.com/1/1105567501435500/project/1161468210277385/task/1211922849393817?focus=true). Pois era a única widget que ainda era configurada inteiramente no admin-client, que é uma implementação mais desatualizada da plataforma.

# Checklist
- [x] Alterar navegação do Editor (admin-client) para enviar o usuário ao canary-client quando quiser editar um Formulário
- [x] Implementar configuração de campos para o formulário no novo administrador
- [x] Garantir que os formulários que já foram criados em produção com seus campos tenham compatibilidade

## Preview:
### Ao clicar em editar deve ser redirecionado para o admin canary
<img width="615" height="812" alt="Captura de Tela 2025-11-27 às 17 21 53" src="https://github.com/user-attachments/assets/3da2b019-f9f7-40ef-af3e-7d56d9f0a963" />

### Layout de edição atualizado
<img width="1027" height="668" alt="Captura de Tela 2025-11-27 às 17 22 34" src="https://github.com/user-attachments/assets/2b5b51b7-0b8a-4c14-93cd-02ce0597aed1" />
<img width="890" height="680" alt="Captura de Tela 2025-11-27 às 17 22 57" src="https://github.com/user-attachments/assets/cfc99cb0-3541-4ae5-b8ab-b5e44eb90de5" />

### Visualização renderizada do formulário ok no Bonde Public
<img width="611" height="745" alt="Captura de Tela 2025-11-27 às 17 24 00" src="https://github.com/user-attachments/assets/34ff4f18-1e4d-48d4-8775-9a7c90b033be" />
