### PR TITLE
feat(canary-client): changed upload files to graphql

### DIFF
--- a/packages/canary-client/src/components/SlateEditor/index.tsx
+++ b/packages/canary-client/src/components/SlateEditor/index.tsx
@@ -15,6 +15,7 @@ import { ImagePlugin, ImageButton } from "@slate-editor/image-plugin";
 import { ColorPlugin, ColorButton, ColorStateModel } from "@slate-editor/color-plugin";
 import { GridPlugin, GridButtonBar } from "@slate-editor/grid-plugin";
 import { EmbedPlugin, EmbedButton } from "@slate-editor/embed-plugin";
+import { useUploadS3 } from '../../graphql/upload-s3';
 
 const Styles = styled.div`
   .editor--root {
@@ -155,50 +156,54 @@ type RichEditorProps = {
   onChange: any
 }
 
-const RichEditor = ({ value, onChange }: RichEditorProps) => (
-  <Styles>
-    <div className='header'>
-      <Header.H5 uppercase>Customização</Header.H5>
-      <Header.H5 uppercase>Preview</Header.H5>
-    </div>
-    <SlateEditor
-      plugins={plugins}
-      initialState={value}
-      onChange={onChange}
-    >
-      {/* Toolbar */}
-      <SlateToolbar className='buttons'>
-        <BoldButton className={classNames.button} />
-        <ItalicButton className={classNames.button} />
-        <UnderlineButton className={classNames.button} />
-        <AlignmentButtonBar className={classNames.button} />
-        <StrikethroughButton className={classNames.button} />
-        <LinkButton className={classNames.button} />
-        <ImageButton
-          className={classNames.button}
-          signingUrl={process.env.REACT_APP_UPLOADS_URL}
-        />
-        <ListButtonBar className={classNames.button} />
-        <ColorButton
-          className={classNames.button}
-          initialState={colorPluginOptions}
-          pickerDefaultPosition={{ x: -520, y: 17 }}
-        />
-        <EmbedButton className={classNames.button} />
-        <GridButtonBar className={classNames.button} />
-      </SlateToolbar>
-      {/* Toolbar */}
-      <SlateToolbar className='inputs'>
-        <FontFamilyDropdown className={classNames.dropdown} />
-        <FontSizeInput
-          {...fontSizePluginOptions}
-          className={classNames.input}
-        />
-      </SlateToolbar>
-      {/* Content */}
-      <SlateContent />
-    </SlateEditor>
-  </Styles>
-);
+const RichEditor = ({ value, onChange }: RichEditorProps) => {
+  const { getSignedUrl } = useUploadS3();
+  
+  return (
+    <Styles>
+      <div className='header'>
+        <Header.H5 uppercase>Customização</Header.H5>
+        <Header.H5 uppercase>Preview</Header.H5>
+      </div>
+      <SlateEditor
+        plugins={plugins}
+        initialState={value}
+        onChange={onChange}
+      >
+        {/* Toolbar */}
+        <SlateToolbar className='buttons'>
+          <BoldButton className={classNames.button} />
+          <ItalicButton className={classNames.button} />
+          <UnderlineButton className={classNames.button} />
+          <AlignmentButtonBar className={classNames.button} />
+          <StrikethroughButton className={classNames.button} />
+          <LinkButton className={classNames.button} />
+          <ImageButton
+            className={classNames.button}
+            getSignedUrl={getSignedUrl}
+          />
+          <ListButtonBar className={classNames.button} />
+          <ColorButton
+            className={classNames.button}
+            initialState={colorPluginOptions}
+            pickerDefaultPosition={{ x: -520, y: 17 }}
+          />
+          <EmbedButton className={classNames.button} />
+          <GridButtonBar className={classNames.button} />
+        </SlateToolbar>
+        {/* Toolbar */}
+        <SlateToolbar className='inputs'>
+          <FontFamilyDropdown className={classNames.dropdown} />
+          <FontSizeInput
+            {...fontSizePluginOptions}
+            className={classNames.input}
+          />
+        </SlateToolbar>
+        {/* Content */}
+        <SlateContent />
+      </SlateEditor>
+    </Styles>
+  );
+};
 
 export default RichEditor;

--- a/packages/canary-client/src/components/UploadFile/index.tsx
+++ b/packages/canary-client/src/components/UploadFile/index.tsx
@@ -7,6 +7,7 @@ import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 import Image from './Image';
 import UploadImageIcon from './UploadImageIcon';
+import { useUploadS3 } from '../../graphql/upload-s3';
 
 interface UploadFieldProps {
   scale?: number
@@ -58,6 +59,7 @@ const Upload: React.FC<Props> = ({ label, name, imageScale, validate, disabled }
   // const [image, setImage] = useState<string>('');
   const { input, meta } = useField(name, { validate });
   const { t } = useTranslation('app');
+  const { getSignedUrl } = useUploadS3();
 
   const onProgress = (args: any) => {
     console.log('onProgress', { args });
@@ -76,6 +78,17 @@ const Upload: React.FC<Props> = ({ label, name, imageScale, validate, disabled }
     uploadInput?.current.click();
   }
 
+  const getSignedUrlWrapper = (file: any, callback: any) => {
+    getSignedUrl(file)
+      .then((signedUrl: string) => {
+        callback({ signedUrl });
+      })
+      .catch((error: any) => {
+        console.error('Error getting signed URL:', error);
+        callback({ error });
+      });
+  };
+
   return (
     <UploadField scale={imageScale}>
       <button onClick={handleClick} title={t('upload.button')} disabled={disabled}>
@@ -89,7 +102,7 @@ const Upload: React.FC<Props> = ({ label, name, imageScale, validate, disabled }
         <Text>{t('upload.information')}</Text>
         {meta.touched && meta.error && <Hint color='error'>{meta.error}</Hint>}
         <ReactS3Uploader
-          signingUrl={process.env.REACT_APP_UPLOADS_URL}
+          getSignedUrl={getSignedUrlWrapper}
           accept="image/*"
           onProgress={onProgress}
           onError={onError}

--- a/packages/canary-client/src/graphql/upload-s3.js
+++ b/packages/canary-client/src/graphql/upload-s3.js
@@ -1,0 +1,67 @@
+import { gql, useMutation } from 'bonde-core-tools';
+
+export const UPLOAD_S3_MUTATION = gql`
+  mutation ($filename: String!, $content_type: String!) {
+    upload_s3(filename: $filename, content_type: $content_type) {
+      signed_url
+    }
+  }
+`;
+
+export const useUploadS3 = () => {
+  const [mutate, { loading, error }] = useMutation(UPLOAD_S3_MUTATION);
+  
+  const getSignedUrl = async (file) => {
+    const result = await mutate({
+      variables: {
+        filename: file.name,
+        content_type: file.type
+      }
+    });
+    return result.data.upload_s3.signed_url;
+  };
+  
+  return { getSignedUrl, loading, error };
+};
+
+export const getSignedUrl = (file, callback) => {
+  fetch(process.env.REACT_APP_DOMAIN_API_GRAPHQL, {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      query: UPLOAD_S3_MUTATION.loc.source.body,
+      variables: { filename: file.name, content_type: file.type }
+    })
+  })
+  .then(res => res.json())
+  .then(response => {
+    if (response.errors) throw new Error(response.errors[0].message);
+    callback({ signedUrl: response.data.upload_s3.signed_url });
+  })
+  .catch(error => {
+    console.error(error);
+    callback({ error });
+  });
+};
+
+
+export const asyncGetSignedUrl = async (file) => {
+  try {
+    const response = await fetch(process.env.REACT_APP_DOMAIN_API_GRAPHQL, {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        query: UPLOAD_S3_MUTATION.loc.source.body,
+        variables: { filename: file.name, content_type: file.type }
+      })
+    })
+    const jsonData = await response.json()
+    return { signedUrl: jsonData.data.upload_s3.signed_url }
+  } catch (error) {
+    console.log(error);
+  }
+};
+
+export default getSignedUrl;

--- a/packages/canary-client/src/scenes/Community/Settings/index.tsx
+++ b/packages/canary-client/src/scenes/Community/Settings/index.tsx
@@ -3,14 +3,14 @@ import {
   Header,
   InputField,
   Success,
-  Validators,
-  S3UploadField
+  Validators
 } from 'bonde-components';
 import { Text, Box, Flex, Image } from 'bonde-components/chakra';
 import { Context as SessionContext } from 'bonde-core-tools';
 import { useTranslation } from "react-i18next";
 import CommunityForm from '../BaseForm';
 import ButtonStyled from '../../../components/ButtonStyled';
+import Upload from '../../../components/UploadFile/index';
 const { isEmail } = Validators;
 
 export const isValidFromEmail = (value: string): string | undefined => {
@@ -37,12 +37,10 @@ const SettingsPage: React.FC = () => {
         <Box bg="white" p={6} w="50%">
           {hasPerm ? (
             <>
-              <S3UploadField
+              <Upload
                 label={t('info.form.fields.image.label')}
-                helpText={t('app:upload.information')}
                 name='community.image'
                 disabled={!hasPerm}
-                signingUrl={process.env.REACT_APP_UPLOADS_URL}
               />
               <InputField
                 name='community.name'


### PR DESCRIPTION
## Contexto
O objetivo dessas mudanças é de alterar toda dependência de upload de imagem que usa a API-Rest para usar agora a mutation upload_s3 da API-GraphQL

## Checklist
- [x] Testar upload de arquivos no editor HTML
- [x] Testar upload de arquivos nas configurações de comunidade

## Issues linkadas
- [Remover dependencia da API-Rest no canary-client](https://app.asana.com/1/1105567501435500/project/1161468210277385/task/1212696645061719?focus=true)

## Screenshots
<img width="1413" height="698" alt="Captura de Tela 2026-01-08 às 15 38 02" src="https://github.com/user-attachments/assets/ebe0678f-2023-4b6c-a6b8-a3a2914cbba9" />

