### PR TITLE
fix(templates): adjusts the creation and update fields for blocks.

### DIFF
--- a/packages/admin-client/src/mobrender/redux/action-creators/async-add-block.js
+++ b/packages/admin-client/src/mobrender/redux/action-creators/async-add-block.js
@@ -39,10 +39,18 @@ mutation ($block: blocks_insert_input!) {
 
 export default ({ widgets_attributes, ...blockAttrs }) => (dispatch, getState, { api }) => {
   const lastPosition = MobSelectors(getState()).getBlockLastPosition()
+  const now = new Date().toISOString();
+  
   const block = {
     ...blockAttrs,
+    created_at: now,     
+    updated_at: now,      
     widgets: {
-      data: widgets_attributes
+      data: widgets_attributes.map(widget => ({
+        ...widget,
+        created_at: now,  
+        updated_at: now 
+      }))
     },
     position: lastPosition + 1
   }


### PR DESCRIPTION
<!-- IMPORTANTE: Por favor confira o arquivo CONTRIBUTING.md para ver o guia de contribuição detalhado e remova os itens que não estiver usando. -->

## Contexto
<!-- Qual problema está tentando resolver? -->
A tarefa consiste em investigar e corrigir um bug que está impedindo a criação dos blocks na interface. Após analise, foi constado que o campo created_at e updated_at não estavam sendo enviados corretamente. Esta correção está relacionada a um chamado de suporte. 

## Checklist
- [x] Corrigir campos created_at e updated_at
<!-- Descreva as principais alterações que este PR faz. -->

## Issues linkadas
[BUG] Erro ao criar blocos na interface do Bonde
](https://app.asana.com/1/1105567501435500/task/1213200560327827)

<!-- Adicione as respectivas issues linkadas a este PR. -->

## Screenshots
<!-- Adicione algumas imagens para haver um preview da sua tarefa, para ajudar desenvolvedores e designers a entender facilmente no que você está trabalhando. -->

### Preview:
<img width="362" height="218" alt="blocs" src="https://github.com/user-attachments/assets/84bdcb3e-0236-488c-b845-88173cc45d7f" />

## Notas de deploy
<!-- Notas de deploy do desenvolvimento da aplicação. Devem ser novas dependências, scripts, etc. -->
Para que essa implementação funcione, é necessário também validar as mudanças no hasura. Dependente desse PR https://github.com/nossas/bonde-hasura/pull/5

## Como testar?
<!-- Adicione algumas instruções de como os reviewers podem testar esse PR. -->
Para a realização dos testes desta tarefa, é necessária a criação de um bloco na página e observar se obteve sucesso.

